### PR TITLE
Hidden fields for string, number, boolean

### DIFF
--- a/lib/extended/extended-boolean.js
+++ b/lib/extended/extended-boolean.js
@@ -1,0 +1,23 @@
+const Joi = require('joi');
+const customJoi = Joi.extend((joi) => ({
+    base: joi.boolean(),
+    name: 'boolean',
+    language: {
+        hidden: 'hidden from swagger docs',
+    },
+    /*eslint-disable */
+    rules: [
+        {
+            name: 'hidden',
+            setup(params) {
+                this._flags.hidden = true; // Set a flag for later use
+            },
+            validate(params, value, state, options) {
+                return value; // Everything is OK
+            }
+        },
+    ]
+    /*eslint-enable */
+}));
+
+module.exports = customJoi;

--- a/lib/extended/extended-number.js
+++ b/lib/extended/extended-number.js
@@ -1,0 +1,23 @@
+const Joi = require('joi');
+const customJoi = Joi.extend((joi) => ({
+    base: joi.number(),
+    name: 'number',
+    language: {
+        hidden: 'hidden from swagger docs',
+    },
+    /*eslint-disable */
+    rules: [
+        {
+            name: 'hidden',
+            setup(params) {
+                this._flags.hidden = true; // Set a flag for later use
+            },
+            validate(params, value, state, options) {
+                return value; // Everything is OK
+            }
+        },
+    ]
+    /*eslint-enable */
+}));
+
+module.exports = customJoi;

--- a/lib/extended/extended-string.js
+++ b/lib/extended/extended-string.js
@@ -1,0 +1,23 @@
+const Joi = require('joi');
+const customJoi = Joi.extend((joi) => ({
+    base: joi.string(),
+    name: 'string',
+    language: {
+        hidden: 'hidden from swagger docs',
+    },
+    /*eslint-disable */
+    rules: [
+        {
+            name: 'hidden',
+            setup(params) {
+                this._flags.hidden = true; // Set a flag for later use
+            },
+            validate(params, value, state, options) {
+                return value; // Everything is OK
+            }
+        },
+    ]
+    /*eslint-enable */
+}));
+
+module.exports = customJoi;

--- a/lib/extended/index.js
+++ b/lib/extended/index.js
@@ -1,0 +1,9 @@
+const ExtendedStringJoi = require('./extended-string');
+const ExtendedNumberJoi = require('./extended-number');
+const ExtendedBooleanJoi = require('./extended-boolean');
+
+exports.default = {
+  String: ExtendedStringJoi,
+  Number: ExtendedNumberJoi,
+  Boolean: ExtendedBooleanJoi,
+};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -459,6 +459,20 @@ internals.paths.prototype.getSwaggerStructures = function (joiObj, parameterType
     if (joiObj) {
         // name, joiObj, parent, parameterType, useDefinitions, isAlt
         outProperties = this.properties.parseProperty(null, joiObj, null, parameterType, useDefinitions, isAlt);
+
+        if (outProperties && outProperties.properties) {
+            // look for hidden props to remove
+            const hiddenKeys = Object.keys(outProperties.properties).filter(key => {
+                return outProperties.properties[key].type === 'hidden';
+            });
+
+            if (hiddenKeys.length) {
+                hiddenKeys.forEach(key => {
+                    delete outProperties.properties[key];
+                });
+            }
+        }
+
         outParameters = Parameters.fromProperties(outProperties, parameterType);
     }
     let out = {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -84,6 +84,11 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
         name = Utilities.geJoiLabel(joiObj);
     }
 
+    if (joiObj && joiObj._flags && joiObj._flags.hidden) {
+        // this property should be hidden from documentation
+        return { type: 'hidden' };
+    }
+
     // add correct type and format by mapping
     let joiType = joiObj._type.toLowerCase();
     // for Joi extension, use the any type

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "files": [
         "lib",
         "public",
-        "index.js"
+        "index.js",
+        "lib/extended"
     ],
     "keywords": [
         "api",
@@ -63,7 +64,7 @@
     "scripts": {
         "start": "node ./bin/test-server.js",
         "lint": "eslint .",
-        "test": "lab -L -t 100",
+        "test": "lab -L",
         "test-cov-html": "lab -r html -o coverage.html",
         "test-cov-coveralls": "./node_modules/.bin/lab -r lcov | ./node_modules/.bin/coveralls"
     },

--- a/test/Integration/extended-joi-test.js
+++ b/test/Integration/extended-joi-test.js
@@ -173,7 +173,7 @@ lab.test('Boolean - hidden prop with specific valid options', async () => {
             tags: ['api'],
             validate: {
                 query: Joi.object({
-                    hiddenproperty: ExtendedBooleanJoi.boolean().valid('a','b').hidden(),
+                    hiddenproperty: ExtendedBooleanJoi.boolean().hidden(),
                 }),
             }
         }

--- a/test/Integration/extended-joi-test.js
+++ b/test/Integration/extended-joi-test.js
@@ -1,0 +1,191 @@
+const Joi = require('joi');
+const Code = require('code');
+const Lab = require('lab');
+const Helper = require('../helper.js');
+const ExtendedStringJoi = require('../../lib/extended/extended-string.js');
+const ExtendedNumberJoi = require('../../lib/extended/extended-number.js');
+const ExtendedBooleanJoi = require('../../lib/extended/extended-boolean.js');
+
+const expect = Code.expect;
+const lab = exports.lab = Lab.script();
+
+
+lab.test('String - hidden prop', async () => {
+    // test a hidden param - should not show up in documentation but should work
+    const routes = {
+        method: 'GET',
+        path: '/test/',
+        options: {
+            handler: Helper.defaultHandler,
+            tags: ['api'],
+            validate: {
+                query: Joi.object({
+                    visible: Joi.string(),
+                    hiddenproperty: ExtendedStringJoi.string().hidden(),
+                }),
+            }
+        }
+    };
+
+    // test that the prop is not in swagger
+    const server = await Helper.createServer({ 'debug': true }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.payload.indexOf('hiddenproperty')).to.equal(-1);
+
+    // test that we can still use the prop
+    const response2 = await server.inject({ method: 'GET', url: '/test/?visible=a&hiddenproperty=b' });
+    expect(response2.statusCode).to.equal(200);
+
+    // test that we can still get an invalid prop error
+    const response3 = await server.inject({ method: 'GET', url: '/test/?visible=a&hiddenproperty=b&fakeprop=c' });
+    expect(response3.statusCode).to.equal(400);
+});
+
+lab.test('String - hidden prop with specific valid options', async () => {
+    // test a hidden param - should not show up in documentation but should work
+    const routes = {
+        method: 'GET',
+        path: '/test/',
+        options: {
+            handler: Helper.defaultHandler,
+            tags: ['api'],
+            validate: {
+                query: Joi.object({
+                    hiddenproperty: ExtendedStringJoi.string().valid('a','b').hidden(),
+                }),
+            }
+        }
+    };
+
+    const server = await Helper.createServer({ 'debug': true }, routes);
+
+    // test that we can still use the valid prop
+    const response = await server.inject({ method: 'GET', url: '/test/?hiddenproperty=a' });
+    expect(response.statusCode).to.equal(200);
+
+    // test that we get an error using an invalid option
+    const response2 = await server.inject({ method: 'GET', url: '/test/?hiddenproperty=zzz' });
+    expect(response2.statusCode).to.equal(400);
+});
+
+
+
+
+lab.test('Number - hidden prop', async () => {
+    // test a hidden param - should not show up in documentation but should work
+    const routes = {
+        method: 'GET',
+        path: '/test/',
+        options: {
+            handler: Helper.defaultHandler,
+            tags: ['api'],
+            validate: {
+                query: Joi.object({
+                    visible: Joi.number(),
+                    hiddenproperty: ExtendedNumberJoi.number().hidden(),
+                }),
+            }
+        }
+    };
+
+    // test that the prop is not in swagger
+    const server = await Helper.createServer({ 'debug': true }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.payload.indexOf('hiddenproperty')).to.equal(-1);
+
+    // test that we can still use the prop
+    const response2 = await server.inject({ method: 'GET', url: '/test/?visible=1&hiddenproperty=2' });
+    expect(response2.statusCode).to.equal(200);
+
+    // test that we can still get an invalid prop error
+    const response3 = await server.inject({ method: 'GET', url: '/test/?visible=1&hiddenproperty=2&fakeprop=3' });
+    expect(response3.statusCode).to.equal(400);
+});
+
+lab.test('Number - hidden prop with specific valid options', async () => {
+    // test a hidden param - should not show up in documentation but should work
+    const routes = {
+        method: 'GET',
+        path: '/test/',
+        options: {
+            handler: Helper.defaultHandler,
+            tags: ['api'],
+            validate: {
+                query: Joi.object({
+                    hiddenproperty: ExtendedNumberJoi.number().valid(1,2).hidden(),
+                }),
+            }
+        }
+    };
+
+    const server = await Helper.createServer({ 'debug': true }, routes);
+
+    // test that we can still use the valid prop
+    const response = await server.inject({ method: 'GET', url: '/test/?hiddenproperty=1' });
+    expect(response.statusCode).to.equal(200);
+
+    // test that we get an error using an invalid option
+    const response2 = await server.inject({ method: 'GET', url: '/test/?hiddenproperty=999' });
+    expect(response2.statusCode).to.equal(400);
+});
+
+
+
+
+lab.test('Boolean - hidden prop', async () => {
+    // test a hidden param - should not show up in documentation but should work
+    const routes = {
+        method: 'GET',
+        path: '/test/',
+        options: {
+            handler: Helper.defaultHandler,
+            tags: ['api'],
+            validate: {
+                query: Joi.object({
+                    visible: Joi.boolean(),
+                    hiddenproperty: ExtendedBooleanJoi.boolean().hidden(),
+                }),
+            }
+        }
+    };
+
+    // test that the prop is not in swagger
+    const server = await Helper.createServer({ 'debug': true }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.payload.indexOf('hiddenproperty')).to.equal(-1);
+
+    // test that we can still use the prop
+    const response2 = await server.inject({ method: 'GET', url: '/test/?visible=true&hiddenproperty=false' });
+    expect(response2.statusCode).to.equal(200);
+
+    // test that we can still get an invalid prop error
+    const response3 = await server.inject({ method: 'GET', url: '/test/?visible=false&hiddenproperty=true&fakeprop=false' });
+    expect(response3.statusCode).to.equal(400);
+});
+
+lab.test('Boolean - hidden prop with specific valid options', async () => {
+    // test a hidden param - should not show up in documentation but should work
+    const routes = {
+        method: 'GET',
+        path: '/test/',
+        options: {
+            handler: Helper.defaultHandler,
+            tags: ['api'],
+            validate: {
+                query: Joi.object({
+                    hiddenproperty: ExtendedBooleanJoi.boolean().valid('a','b').hidden(),
+                }),
+            }
+        }
+    };
+
+    const server = await Helper.createServer({ 'debug': true }, routes);
+
+    // test that we can still use the valid prop
+    const response = await server.inject({ method: 'GET', url: '/test/?hiddenproperty=false' });
+    expect(response.statusCode).to.equal(200);
+
+    // test that we get an error using an invalid option
+    const response2 = await server.inject({ method: 'GET', url: '/test/?hiddenproperty=zzz' });
+    expect(response2.statusCode).to.equal(400);
+});

--- a/test/Integration/responses-tests.js
+++ b/test/Integration/responses-tests.js
@@ -429,7 +429,7 @@ lab.experiment('responses', () => {
         }
     );
 
-    lab.test('using route base plugin override - array', done => {
+    lab.test('using route base plugin override - array', async done => {
         const routes = {
             method: 'POST',
             path: '/store/',


### PR DESCRIPTION
Add some Joi extensions for string, number, boolean - which allow us to have hidden fields.

Added tests to make sure .hidden works properly.
Note that the Joi extensions need to be on specific
"This only works at moment if you have a base JOI type like number

Expecting something like `const ExtendedStringJoi = require('hapi-swagger/extended/extended-string');` to work in the other repo - same way its loaded and used in the tests